### PR TITLE
Update ch_5.3_restart_strategies.livemd, fix termination reason typo for temporary_dummy

### DIFF
--- a/chapters/ch_5.3_restart_strategies.livemd
+++ b/chapters/ch_5.3_restart_strategies.livemd
@@ -176,7 +176,7 @@ Supervisor.stop(supervisor_pid)
 ```elixir
 # Test abnormal termination of child with `:temporary` restart strategy
 # Notice how the GenServer is NOT restarted
-GenServer.cast(:temporary_dummy, :stop_gracefully)
+GenServer.cast(:temporary_dummy, :crash)
 ```
 
 ```elixir


### PR DESCRIPTION
fix termination reason typo for temporary_dummy, expected `:crash since` `stop_gracefully` has been demonstrated earlier